### PR TITLE
removed violet blue from bad word list

### DIFF
--- a/example/wordlists/badngramlist.txt
+++ b/example/wordlists/badngramlist.txt
@@ -127,7 +127,6 @@ tub girl
 tunnel of love
 two on one
 urethra play
-violet blue
 violet wand
 wet dream
 wet spot


### PR DESCRIPTION
It's a person's name, and not a vulgar phrase.
